### PR TITLE
adding in center justify and left justify

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ $('.fondant-editor').fondant('remove');
 // Font Style
 $('.fondant-editor').fondant('bold');
 $('.fondant-editor').fondant('italic');
+$('.fondant-editor').fondant('center');
+$('.fondant-editor').fondant('left');
 
 // Block elements
 $('.fondant-editor').fondant('p');

--- a/spec/fondant_spec.coffee
+++ b/spec/fondant_spec.coffee
@@ -21,7 +21,7 @@ describe "Fondant", ->
         expect($.fn.fondant.defaults.buttons).toBeDefined()
 
       it "should generate a toolbar with only the buttons specified", ->
-        editor = $('<textarea>').fondant { toolbar: true, buttons: [ 'bold', 'italic' ] }
+        editor = $('<textarea>').fondant { toolbar: true, buttons: [ 'bold', 'italic', 'center', 'left' ] }
         expect(editor.find('.fondant-toolbar').children().length).toBe(2)
 
       it "should not create a toolbar if toolbar is set to false", ->
@@ -145,6 +145,12 @@ describe "Fondant", ->
 
       it "should apply italic", ->
         expect(editor).toApplyFormatAndMatch('italic', /^<i>Test 123<\/i>$/i)
+
+      it "should apply center justify", ->
+        expect(editor).toApplyFormatAndMatch('justifycenter', /^<p class="center">Test 123<\/p>$/i)
+
+      it "should apply left justify", ->
+        expect(editor).toApplyFormatAndMatch('justifyleft', /^<p class="left">Test 123<\/p>$/i)
 
       it "should apply paragraph", ->
         expect(editor).toApplyFormatAndMatch('p', /^<p>Test 123<\/p>$/)

--- a/spec/fondant_spec.js
+++ b/spec/fondant_spec.js
@@ -28,7 +28,7 @@
           var editor;
           editor = $('<textarea>').fondant({
             toolbar: true,
-            buttons: ['bold', 'italic']
+            buttons: ['bold', 'italic', 'center', 'left']
           });
           return expect(editor.find('.fondant-toolbar').children().length).toBe(2);
         });
@@ -159,6 +159,12 @@
         });
         it("should apply italic", function() {
           return expect(editor).toApplyFormatAndMatch('italic', /^<i>Test 123<\/i>$/i);
+        });
+        it("should apply center justify", function() {
+          return expect(editor).toApplyFormatAndMatch('justifycenter', /^<i>Test 123<\/i>$/i);
+        });
+        it("should apply left justify", function() {
+          return expect(editor).toApplyFormatAndMatch('justifyleft', /^<i>Test 123<\/i>$/i);
         });
         it("should apply paragraph", function() {
           return expect(editor).toApplyFormatAndMatch('p', /^<p>Test 123<\/p>$/);

--- a/src/fondant.coffee
+++ b/src/fondant.coffee
@@ -41,7 +41,7 @@
 # * `buttons` - An array of commands to include as buttons. Links & custom html cannot be
 #   automatically addes as a toolbar button because there needs to be some form of input between
 #   the button click and the application. Everything else is available to use.
-#   (default: [ 'bold', 'italic', 'p', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'ol', 'ul', 'indent',
+#   (default: [ 'bold', 'italic', 'center', 'left', 'p', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'ol', 'ul', 'indent',
 #   'outdent', 'remove', 'unlink', 'undo', 'redo' ]`)
 #
 
@@ -299,7 +299,7 @@ if typeof $ isnt 'undefined'
     #
     actions: [
       'remove', 'custom', 'undo', 'redo',
-      'bold', 'italic',
+      'bold', 'italic', 'center', 'left',
       'p', 'h1', 'h2', 'h3', 'h4', 'blockquote',
       'ol', 'ul', 'indent', 'outdent',
       'link', 'unlink'
@@ -326,8 +326,12 @@ if typeof $ isnt 'undefined'
     #
     # * `bold()`
     # * `italic()`
+    # * `center()`
+    # * `left()`
     bold:   -> @applyFormat 'bold'
     italic: -> @applyFormat 'italic'
+    center: -> @applyFormat 'justifycenter'
+    left: -> @applyFormat 'justifyleft'
 
     # ### Block Formats
     #
@@ -453,7 +457,7 @@ if typeof $ isnt 'undefined'
     prefix: 'fondant'
     toolbar: true
     buttons: [
-      'bold', 'italic',
+      'bold', 'italic', 'center', 'left',
       'p', 'h1', 'h2', 'h3', 'h4', 'blockquote',
       'ol', 'ul', 'indent', 'outdent',
       'remove', 'unlink', 'undo', 'redo'

--- a/src/fondant.js
+++ b/src/fondant.js
@@ -170,7 +170,7 @@
         return this.focus();
       };
 
-      Fondant.prototype.actions = ['remove', 'custom', 'undo', 'redo', 'bold', 'italic', 'p', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'ol', 'ul', 'indent', 'outdent', 'link', 'unlink'];
+      Fondant.prototype.actions = ['remove', 'custom', 'undo', 'redo', 'bold', 'italic', 'center', 'left', 'p', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'ol', 'ul', 'indent', 'outdent', 'link', 'unlink'];
 
       Fondant.prototype.remove = function() {
         return this.applyFormat('removeFormat');
@@ -192,6 +192,14 @@
 
       Fondant.prototype.italic = function() {
         return this.applyFormat('italic');
+      };
+
+      Fondant.prototype.center = function() {
+        return this.applyFormat('justifycenter');
+      };
+
+      Fondant.prototype.left = function() {
+        return this.applyFormat('justifyleft');
       };
 
       Fondant.prototype.p = function() {
@@ -305,7 +313,7 @@
     $.fn.fondant.defaults = {
       prefix: 'fondant',
       toolbar: true,
-      buttons: ['bold', 'italic', 'p', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'ol', 'ul', 'indent', 'outdent', 'remove', 'unlink', 'undo', 'redo']
+      buttons: ['bold', 'italic', 'center', 'left', 'p', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'ol', 'ul', 'indent', 'outdent', 'remove', 'unlink', 'undo', 'redo']
     };
   }
 


### PR DESCRIPTION
@philtr I added in a justify left and center (cellucor needs it a ton, and it's kind of helpful). Please review the commit... for now, i also forked my own fondant-rails, for cellucor, so it points to my own version of fondant, until you guys merge this in.

It just adds a class of "center" or "left" to the element. It's up to the css/frontend dev to do anything with it.
